### PR TITLE
Changed to MIT license and updated README.md and package.json

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,13 +1,20 @@
-Copyright 2016 Itai Steinherz
+MIT License
 
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
+Copyright (c) 2016 Itai Steinherz
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
 
-    http://www.apache.org/licenses/LICENSE-2.0
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
 
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -2,11 +2,11 @@
 A web and command line interface for the Neo4j Graph Database.
 
 ## Quick Start
-Download and install Neo4j, which can be found [here](https://neo4j.com/download/). Then, start the
-database.
+Download and install Neo4j, which can be found [here](https://neo4j.com/download/).
+Then, start the database.
 
 Configure the `config/default.json` file with the desired port for the webserver
-to run on, and the username, password and url to your database.
+to run on and the username, password and url to your database.
 
 Clone the repository:
 
@@ -27,8 +27,11 @@ Start the server:
 npm start
 ```
 
-Then, go to [http://localhost:3000](http://localhost:3000) (or any other port specified in
-the config/default.json file).
+Then, go to [http://localhost:3000](http://localhost:3000) (or any other port
+specified in the config/default.json file).
+
+## Notes
+This project adheres to the Semantic Versioning 
 
 ## License
-[Apache-2.0](LICENSE)
+[MIT License](LICENSE)

--- a/README.md
+++ b/README.md
@@ -30,8 +30,8 @@ npm start
 Then, go to [http://localhost:3000](http://localhost:3000) (or any other port
 specified in the config/default.json file).
 
-## Notes
-This project adheres to the Semantic Versioning 
-
 ## License
 [MIT License](LICENSE)
+
+## Notes
+This project adheres to the [Semantic Versioning](http://semver.org/).

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "javascript"
   ],
   "author": "Itai Steinherz",
-  "license": "Apache-2.0",
+  "license": "MIT",
   "bugs": {
     "url": "https://github.com/itaisteinherz/neo4j-console/issues"
   },


### PR DESCRIPTION
Updated the LICENSE file to use the MIT license. In the README.md file, narrowed down lines to 80 characters and updated the license information. In the package.json file, updated the license field with the new license.